### PR TITLE
Enabled core library desugaring to support ZonedDateTime on API 24+

### DIFF
--- a/code/.idea/misc.xml
+++ b/code/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/code/app/build.gradle.kts
+++ b/code/app/build.gradle.kts
@@ -27,6 +27,7 @@ android {
         }
     }
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
@@ -46,4 +47,7 @@ dependencies {
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
+
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+
 }


### PR DESCRIPTION
This updates the Gradle configuration so enable core library desugaring.
This allows the app to use ZonedDateTime and related Classes for devices below API level 26.

This change unblocks event creation/editing and prevents runtime errors related to java.time.

Our app  **will not compile without this.**