### PR TITLE
Improve map search and address-based venue flow

### DIFF
--- a/code/app/src/main/java/com/example/eventlottery/Event.java
+++ b/code/app/src/main/java/com/example/eventlottery/Event.java
@@ -64,6 +64,8 @@ public class Event {
     private Double venueLatitude;
     /** Venue longitude (WGS84), optional. */
     private Double venueLongitude;
+    /** Human-readable venue address; users enter this (not raw coordinates). */
+    private String venueAddress;
     /** When true, entrants must be within {@link #geolocationRadiusMeters} of the venue to join the waitlist. */
     private boolean requireGeolocationForWaitlist;
     /** Max distance from venue in meters; defaults in app logic when null. */
@@ -278,6 +280,14 @@ public class Event {
 
     public void setVenueLongitude(Double venueLongitude) {
         this.venueLongitude = venueLongitude;
+    }
+
+    public String getVenueAddress() {
+        return venueAddress;
+    }
+
+    public void setVenueAddress(String venueAddress) {
+        this.venueAddress = venueAddress;
     }
 
     public boolean isRequireGeolocationForWaitlist() {

--- a/code/app/src/main/java/com/example/eventlottery/EventOverviewFragment.java
+++ b/code/app/src/main/java/com/example/eventlottery/EventOverviewFragment.java
@@ -1107,32 +1107,6 @@ public class EventOverviewFragment extends Fragment implements
     }
 
     /**
-     * Parses an event timestamp field from Firestore into the local time zone.
-     *
-     * @param documentSnapshot Firestore event document.
-     * @param fieldName Name of the date field to parse.
-     * @return Parsed date, or the current time as a fallback.
-     */
-    private ZonedDateTime readEventDate(DocumentSnapshot documentSnapshot, String fieldName) {
-        Object rawValue = documentSnapshot.get(fieldName);
-        if (rawValue instanceof Timestamp) {
-            Timestamp timestamp = (Timestamp) rawValue;
-            return ZonedDateTime.ofInstant(
-                    Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanoseconds()),
-                    ZoneId.systemDefault()
-            );
-        }
-        if (rawValue instanceof String) {
-            try {
-                return ZonedDateTime.parse((String) rawValue);
-            } catch (Exception ignored) {
-                // Fall through to the default below.
-            }
-        }
-        return ZonedDateTime.now();
-    }
-
-    /**
      * Returns the input string unless it is blank, in which case the fallback is returned.
      *
      * @param value Candidate value.

--- a/code/app/src/main/java/com/example/eventlottery/HomePageFragment.java
+++ b/code/app/src/main/java/com/example/eventlottery/HomePageFragment.java
@@ -20,7 +20,9 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
+import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -32,6 +34,7 @@ import com.example.eventlottery.profiles.ProfileListFragment;
 import com.example.eventlottery.profiles.User;
 import com.example.eventlottery.profiles.UserProfileFragment;
 import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.MaterialAutoCompleteTextView;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.auth.FirebaseAuth;
@@ -42,7 +45,11 @@ import com.google.firebase.firestore.QueryDocumentSnapshot;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * Home page fragment that displays a list of events fetched from Firestore.
@@ -53,10 +60,12 @@ public class HomePageFragment extends Fragment {
     private EventAdapter adapter;
 
     private TextInputLayout keywordLayout;
+    private TextInputLayout tagLayout;
     private TextInputLayout availableDateLayout;
     private TextInputLayout minCapacityLayout;
 
     private TextInputEditText keywordInput;
+    private MaterialAutoCompleteTextView tagInput;
     private TextInputEditText availableDateInput;
     private TextInputEditText minCapacityInput;
     private CheckBox openNowOnlyCheckbox;
@@ -79,9 +88,11 @@ public class HomePageFragment extends Fragment {
 
         ListView listView = view.findViewById(R.id.list_view);
         keywordLayout = view.findViewById(R.id.input_search_keyword_layout);
+        tagLayout = view.findViewById(R.id.input_search_tag_layout);
         availableDateLayout = view.findViewById(R.id.input_available_date_layout);
         minCapacityLayout = view.findViewById(R.id.input_min_capacity_layout);
         keywordInput = view.findViewById(R.id.input_search_keyword);
+        tagInput = view.findViewById(R.id.input_search_tag);
         availableDateInput = view.findViewById(R.id.input_available_date);
         minCapacityInput = view.findViewById(R.id.input_min_capacity);
         openNowOnlyCheckbox = view.findViewById(R.id.checkbox_open_now_only);
@@ -95,6 +106,7 @@ public class HomePageFragment extends Fragment {
         applyFiltersButton.setOnClickListener(v -> applyFilters());
         clearFiltersButton.setOnClickListener(v -> {
             if (keywordInput != null) keywordInput.setText("");
+            if (tagInput != null) tagInput.setText("");
             if (availableDateInput != null) availableDateInput.setText("");
             if (minCapacityInput != null) minCapacityInput.setText("");
             if (openNowOnlyCheckbox != null) openNowOnlyCheckbox.setChecked(false);
@@ -158,6 +170,7 @@ public class HomePageFragment extends Fragment {
                             Log.e("HomePageFragment", "Error parsing event: " + document.getId(), e);
                         }
                     }
+                    refreshTagAutocompleteSuggestions();
                     applyFilters();
                 })
                 .addOnFailureListener(e -> {
@@ -261,14 +274,43 @@ public class HomePageFragment extends Fragment {
 
     private void clearFilterErrors() {
         if (keywordLayout != null) keywordLayout.setError(null);
+        if (tagLayout != null) tagLayout.setError(null);
         if (availableDateLayout != null) availableDateLayout.setError(null);
         if (minCapacityLayout != null) minCapacityLayout.setError(null);
+    }
+
+    /**
+     * Fills the tag field dropdown with distinct tags from loaded events (lowercase, sorted).
+     */
+    private void refreshTagAutocompleteSuggestions() {
+        if (tagInput == null) {
+            return;
+        }
+        Set<String> tags = new HashSet<>();
+        for (Event e : allEvents) {
+            if (e.getTags() == null) {
+                continue;
+            }
+            for (String t : e.getTags()) {
+                if (t != null && !t.trim().isEmpty()) {
+                    tags.add(t.trim().toLowerCase(Locale.US));
+                }
+            }
+        }
+        List<String> sorted = new ArrayList<>(tags);
+        Collections.sort(sorted);
+        ArrayAdapter<String> tagAdapter = new ArrayAdapter<>(
+                requireContext(),
+                android.R.layout.simple_dropdown_item_1line,
+                sorted);
+        tagInput.setAdapter(tagAdapter);
     }
 
     private void applyFilters() {
         clearFilterErrors();
 
         String keyword = valueOf(keywordInput).toLowerCase(Locale.US).trim();
+        String tagQuery = valueOf(tagInput).toLowerCase(Locale.US).trim();
         String availableDateRaw = valueOf(availableDateInput).trim();
         String minCapacityRaw = valueOf(minCapacityInput).trim();
         boolean openNowOnly = openNowOnlyCheckbox != null && openNowOnlyCheckbox.isChecked();
@@ -301,6 +343,7 @@ public class HomePageFragment extends Fragment {
         filteredEvents.clear();
         for (Event event : allEvents) {
             if (!matchesKeyword(event, keyword)) continue;
+            if (!matchesTagFilter(event, tagQuery)) continue;
             if (!matchesAvailability(event, availableDate, openNowOnly, now)) continue;
             if (!matchesCapacity(event, minCapacity)) continue;
             filteredEvents.add(event);
@@ -320,6 +363,31 @@ public class HomePageFragment extends Fragment {
                 if (tag != null && tag.toLowerCase(Locale.US).contains(keyword)) {
                     return true;
                 }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * When non-empty, only events that have at least one tag matching the query (exact or substring, case-insensitive).
+     */
+    private boolean matchesTagFilter(Event event, String tagQuery) {
+        if (tagQuery.isEmpty()) {
+            return true;
+        }
+        if (event.getTags() == null || event.getTags().isEmpty()) {
+            return false;
+        }
+        for (String tag : event.getTags()) {
+            if (tag == null) {
+                continue;
+            }
+            String normalized = tag.toLowerCase(Locale.US).trim();
+            if (normalized.isEmpty()) {
+                continue;
+            }
+            if (normalized.equals(tagQuery) || normalized.contains(tagQuery)) {
+                return true;
             }
         }
         return false;
@@ -350,8 +418,10 @@ public class HomePageFragment extends Fragment {
         return capacity != null && capacity >= minCapacity;
     }
 
-    private String valueOf(TextInputEditText editText) {
-        if (editText == null || editText.getText() == null) return "";
-        return editText.getText().toString();
+    private String valueOf(EditText field) {
+        if (field == null || field.getText() == null) {
+            return "";
+        }
+        return field.getText().toString();
     }
 }

--- a/code/app/src/main/java/com/example/eventlottery/creation/CreateEventFragment.java
+++ b/code/app/src/main/java/com/example/eventlottery/creation/CreateEventFragment.java
@@ -17,6 +17,10 @@
  *      - TODO: fix event period check to let existing events have registration open dates
  *              earlier than the current date. I may wish to hide/lock the registration Open
  *              field from editing users entirely if the registration period has already begun.
+ *      - TODO: Move geolocation stuff to their own dedicated buisness logic class in the
+ *              geolocation package
+ *      - TODO: Move validation stuff into it's own dedicated validation logic class.
+ *              (and potentially make a subpackage creaton.validation)
  *</p>
  *
  * @author Grace MacKenzie
@@ -54,6 +58,8 @@ import android.widget.Toast;
 import android.widget.ToggleButton;
 
 import com.example.eventlottery.Event;
+import com.example.eventlottery.geolocation.GeocodeCallback;
+import com.example.eventlottery.geolocation.GeocodeResult;
 import com.example.eventlottery.HomePageFragment;
 import com.example.eventlottery.R;
 import com.google.firebase.firestore.CollectionReference;
@@ -648,22 +654,6 @@ public class CreateEventFragment extends Fragment {
         getParentFragmentManager().setFragmentResult("editEventResult", result);
         if (getParentFragmentManager().getBackStackEntryCount() > 0) {
             getParentFragmentManager().popBackStack();
-        }
-    }
-
-    private interface GeocodeCallback {
-        void onResult(@Nullable GeocodeResult result);
-    }
-
-    private static final class GeocodeResult {
-        final double latitude;
-        final double longitude;
-        final String formattedAddress;
-
-        GeocodeResult(double latitude, double longitude, String formattedAddress) {
-            this.latitude = latitude;
-            this.longitude = longitude;
-            this.formattedAddress = formattedAddress;
         }
     }
 

--- a/code/app/src/main/java/com/example/eventlottery/creation/CreateEventFragment.java
+++ b/code/app/src/main/java/com/example/eventlottery/creation/CreateEventFragment.java
@@ -27,8 +27,12 @@ package com.example.eventlottery.creation;
 import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.location.Address;
+import android.location.Geocoder;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -66,6 +70,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * A Fragment which allows users to create and edit events.
@@ -89,8 +95,7 @@ public class CreateEventFragment extends Fragment {
     private EditText editRegCloseMonth;
     private EditText editRegCloseDay;
     private EditText editCapacity;
-    private EditText editVenueLatitude;
-    private EditText editVenueLongitude;
+    private EditText editVenueAddress;
     private EditText editGeolocationRadius;
     private CheckBox checkboxRequireGeolocation;
     private EditText editEventTags;
@@ -179,8 +184,7 @@ public class CreateEventFragment extends Fragment {
         editRegCloseMonth = view.findViewById(R.id.edit_reg_close_month);
         editRegCloseDay = view.findViewById(R.id.edit_reg_close_day);
         editCapacity = view.findViewById(R.id.edit_capacity);
-        editVenueLatitude = view.findViewById(R.id.edit_venue_latitude);
-        editVenueLongitude = view.findViewById(R.id.edit_venue_longitude);
+        editVenueAddress = view.findViewById(R.id.edit_venue_address);
         editGeolocationRadius = view.findViewById(R.id.edit_geolocation_radius);
         checkboxRequireGeolocation = view.findViewById(R.id.checkbox_require_geolocation);
         editEventTags = view.findViewById(R.id.edit_event_tags);
@@ -219,16 +223,7 @@ public class CreateEventFragment extends Fragment {
                         if (currentEvent.getWaitingListCapacity() != null) {
                             editCapacity.setText(String.valueOf(currentEvent.getWaitingListCapacity()));
                         }
-                        if (currentEvent.getVenueLatitude() != null) {
-                            editVenueLatitude.setText(String.valueOf(currentEvent.getVenueLatitude()));
-                        } else {
-                            editVenueLatitude.setText("");
-                        }
-                        if (currentEvent.getVenueLongitude() != null) {
-                            editVenueLongitude.setText(String.valueOf(currentEvent.getVenueLongitude()));
-                        } else {
-                            editVenueLongitude.setText("");
-                        }
+                        editVenueAddress.setText(currentEvent.getVenueAddress() != null ? currentEvent.getVenueAddress() : "");
                         checkboxRequireGeolocation.setChecked(currentEvent.isRequireGeolocationForWaitlist());
                         if (currentEvent.getGeolocationRadiusMeters() != null) {
                             editGeolocationRadius.setText(String.valueOf(currentEvent.getGeolocationRadiusMeters()));
@@ -264,20 +259,7 @@ public class CreateEventFragment extends Fragment {
             ValidationResult validationResult = validateInput(ctx);
 
             if (validationResult.isValid) {
-                if ( mode == EventCreationMode.CREATE) {
-                    addEvent(Objects.requireNonNull(validationResult.event));
-                } else { // Event mode
-                    // validationResult.event just points to currentEvent
-                    updateEvent(Objects.requireNonNull(validationResult.event));
-                }
-
-                // Navigate back to EventOverviewFragment
-                Bundle result = new Bundle();
-                result.putBoolean("eventUpdated", true); // Tells the destination fragment that the event has been edited
-                getParentFragmentManager().setFragmentResult("editEventResult", result);
-                if (getParentFragmentManager().getBackStackEntryCount() > 0) {
-                    getParentFragmentManager().popBackStack();
-                }
+                saveEvent(Objects.requireNonNull(validationResult.event));
             } else {
                 Toast.makeText(requireContext(), validationResult.errorMessage, Toast.LENGTH_SHORT).show();
             }
@@ -451,8 +433,7 @@ public class CreateEventFragment extends Fragment {
                 regOpen,
                 regClose,
                 editCapacity.getText().toString(),
-                valueTrimmed(editVenueLatitude),
-                valueTrimmed(editVenueLongitude),
+                valueTrimmed(editVenueAddress),
                 valueTrimmed(editGeolocationRadius),
                 checkboxRequireGeolocation.isChecked(),
                 valueTrimmed(editEventTags)
@@ -557,28 +538,18 @@ public class CreateEventFragment extends Fragment {
 
         ArrayList<String> tagList = parseTags(ctx.input.tagsRaw);
 
-        String latRaw = ctx.input.venueLatitude;
-        String lonRaw = ctx.input.venueLongitude;
-        boolean hasLat = !latRaw.isEmpty();
-        boolean hasLon = !lonRaw.isEmpty();
-        if (hasLat != hasLon) {
-            return ValidationResult.invalid(getString(R.string.error_venue_coords_incomplete));
-        }
-        Double vLat = null;
-        Double vLng = null;
-        if (hasLat) {
-            try {
-                vLat = Double.parseDouble(latRaw);
-                vLng = Double.parseDouble(lonRaw);
-            } catch (NumberFormatException e) {
-                return ValidationResult.invalid(getString(R.string.error_venue_coords_invalid));
+        String venueAddress = ctx.input.venueAddress.trim();
+        boolean hasVenueAddress = !venueAddress.isEmpty();
+        if (hasVenueAddress) {
+            if (venueAddress.length() < 5) {
+                return ValidationResult.invalid(getString(R.string.error_venue_address_invalid));
             }
-            if (vLat < -90.0 || vLat > 90.0 || vLng < -180.0 || vLng > 180.0) {
-                return ValidationResult.invalid(getString(R.string.error_venue_coords_invalid));
+            if (looksLikeCoordinates(venueAddress)) {
+                return ValidationResult.invalid(getString(R.string.error_use_address_not_coordinates));
             }
         }
 
-        if (ctx.input.requireGeolocationForWaitlist && vLat == null) {
+        if (ctx.input.requireGeolocationForWaitlist && !hasVenueAddress) {
             return ValidationResult.invalid(getString(R.string.error_geo_requires_venue));
         }
 
@@ -624,14 +595,109 @@ public class CreateEventFragment extends Fragment {
         // Set poster image of returnEvent
         returnEvent.setPosterImage(selectedPosterImage);
 
-        // Set location support for returnEvent
+        // Set location support for returnEvent (lat/lng filled after geocoding when saving)
         returnEvent.setTags(tagList);
-        returnEvent.setVenueLatitude(vLat);
-        returnEvent.setVenueLongitude(vLng);
+        returnEvent.setVenueAddress(hasVenueAddress ? venueAddress : null);
+        returnEvent.setVenueLatitude(null);
+        returnEvent.setVenueLongitude(null);
         returnEvent.setRequireGeolocationForWaitlist(ctx.input.requireGeolocationForWaitlist);
         returnEvent.setGeolocationRadiusMeters(geoRadius);
 
         return ValidationResult.valid(returnEvent);
+    }
+
+    private static boolean looksLikeCoordinates(String raw) {
+        if (raw == null) {
+            return false;
+        }
+        String t = raw.trim();
+        return t.matches("^-?\\d+(\\.\\d+)?\\s*,\\s*-?\\d+(\\.\\d+)?$");
+    }
+
+    private void saveEvent(@NonNull Event event) {
+        String address = event.getVenueAddress();
+        if (address == null || address.trim().isEmpty()) {
+            persistAndClose(event);
+            return;
+        }
+
+        geocodeAddress(address, geocodeResult -> {
+            if (!isAdded()) {
+                return;
+            }
+            if (geocodeResult == null) {
+                Toast.makeText(requireContext(), getString(R.string.error_venue_address_geocode), Toast.LENGTH_SHORT).show();
+                return;
+            }
+            event.setVenueLatitude(geocodeResult.latitude);
+            event.setVenueLongitude(geocodeResult.longitude);
+            event.setVenueAddress(geocodeResult.formattedAddress);
+            persistAndClose(event);
+        });
+    }
+
+    private void persistAndClose(@NonNull Event event) {
+        if (mode == EventCreationMode.CREATE) {
+            addEvent(event);
+        } else {
+            updateEvent(event);
+        }
+
+        Bundle result = new Bundle();
+        result.putBoolean("eventUpdated", true);
+        getParentFragmentManager().setFragmentResult("editEventResult", result);
+        if (getParentFragmentManager().getBackStackEntryCount() > 0) {
+            getParentFragmentManager().popBackStack();
+        }
+    }
+
+    private interface GeocodeCallback {
+        void onResult(@Nullable GeocodeResult result);
+    }
+
+    private static final class GeocodeResult {
+        final double latitude;
+        final double longitude;
+        final String formattedAddress;
+
+        GeocodeResult(double latitude, double longitude, String formattedAddress) {
+            this.latitude = latitude;
+            this.longitude = longitude;
+            this.formattedAddress = formattedAddress;
+        }
+    }
+
+    private void geocodeAddress(@NonNull String address, @NonNull GeocodeCallback callback) {
+        if (!Geocoder.isPresent()) {
+            callback.onResult(null);
+            return;
+        }
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Handler mainHandler = new Handler(Looper.getMainLooper());
+        executor.execute(() -> {
+            GeocodeResult result = null;
+            try {
+                Geocoder geocoder = new Geocoder(requireContext(), Locale.getDefault());
+                List<Address> addresses = geocoder.getFromLocationName(address, 1);
+                if (addresses != null && !addresses.isEmpty()) {
+                    Address resolved = addresses.get(0);
+                    String resolvedAddress = resolved.getAddressLine(0);
+                    if (resolvedAddress == null || resolvedAddress.trim().isEmpty()) {
+                        resolvedAddress = address.trim();
+                    }
+                    result = new GeocodeResult(
+                            resolved.getLatitude(),
+                            resolved.getLongitude(),
+                            resolvedAddress
+                    );
+                }
+            } catch (Exception ignored) {
+            }
+
+            GeocodeResult finalResult = result;
+            mainHandler.post(() -> callback.onResult(finalResult));
+            executor.shutdown();
+        });
     }
 
 }

--- a/code/app/src/main/java/com/example/eventlottery/creation/EventInput.java
+++ b/code/app/src/main/java/com/example/eventlottery/creation/EventInput.java
@@ -17,8 +17,7 @@ public class EventInput {
     public final String registrationOpen;
     public final String registrationClose;
     public final String waitingListCapacity;
-    public final String venueLatitude;
-    public final String venueLongitude;
+    public final String venueAddress;
     public final String geolocationRadiusMeters;
     public final boolean requireGeolocationForWaitlist;
     public final String tagsRaw;
@@ -29,8 +28,7 @@ public class EventInput {
             String registrationOpen,
             String registrationClose,
             String waitingListCapacity,
-            String venueLatitude,
-            String venueLongitude,
+            String venueAddress,
             String geolocationRadiusMeters,
             boolean requireGeolocationForWaitlist,
             String tagsRaw
@@ -40,8 +38,7 @@ public class EventInput {
         this.registrationOpen = registrationOpen;
         this.registrationClose = registrationClose;
         this.waitingListCapacity = waitingListCapacity;
-        this.venueLatitude = venueLatitude;
-        this.venueLongitude = venueLongitude;
+        this.venueAddress = venueAddress;
         this.geolocationRadiusMeters = geolocationRadiusMeters;
         this.requireGeolocationForWaitlist = requireGeolocationForWaitlist;
         this.tagsRaw = tagsRaw;

--- a/code/app/src/main/java/com/example/eventlottery/geolocation/GeocodeCallback.java
+++ b/code/app/src/main/java/com/example/eventlottery/geolocation/GeocodeCallback.java
@@ -1,0 +1,7 @@
+package com.example.eventlottery.geolocation;
+
+import androidx.annotation.Nullable;
+
+public interface GeocodeCallback {
+    void onResult(@Nullable GeocodeResult result);
+}

--- a/code/app/src/main/java/com/example/eventlottery/geolocation/GeocodeResult.java
+++ b/code/app/src/main/java/com/example/eventlottery/geolocation/GeocodeResult.java
@@ -1,0 +1,13 @@
+package com.example.eventlottery.geolocation;
+
+public class GeocodeResult {
+    public final double latitude;
+    public final double longitude;
+    public final String formattedAddress;
+
+    public GeocodeResult(double latitude, double longitude, String formattedAddress) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.formattedAddress = formattedAddress;
+    }
+}

--- a/code/app/src/main/java/com/example/eventlottery/map/NearbyEventsMapFragment.java
+++ b/code/app/src/main/java/com/example/eventlottery/map/NearbyEventsMapFragment.java
@@ -9,6 +9,9 @@ import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -26,8 +29,10 @@ import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.location.Priority;
 import com.google.android.gms.tasks.CancellationTokenSource;
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
+import com.google.android.material.textfield.TextInputEditText;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 
@@ -41,7 +46,6 @@ import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
 
 import java.io.File;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -54,6 +58,9 @@ import java.util.Set;
  * Markers are grouped by zoom level; tags filter which events are shown.
  */
 public class NearbyEventsMapFragment extends Fragment {
+
+    /** Lowercase trimmed query; filters pins by tag match and event title. */
+    private String mapSearchKeyword = "";
 
     private MapView mapView;
     private final ArrayList<Event> allEvents = new ArrayList<>();
@@ -95,6 +102,40 @@ public class NearbyEventsMapFragment extends Fragment {
                 getParentFragmentManager().popBackStack();
             }
         });
+
+        TextInputEditText searchInput = view.findViewById(R.id.input_map_search);
+        MaterialButton searchBtn = view.findViewById(R.id.btn_map_search);
+        MaterialButton clearSearchBtn = view.findViewById(R.id.btn_map_search_clear);
+        if (searchBtn != null) {
+            searchBtn.setOnClickListener(v -> {
+                if (searchInput != null && searchInput.getText() != null) {
+                    mapSearchKeyword = searchInput.getText().toString().trim().toLowerCase(Locale.US);
+                } else {
+                    mapSearchKeyword = "";
+                }
+                hideKeyboard(v);
+                refreshMarkers();
+            });
+        }
+        if (clearSearchBtn != null) {
+            clearSearchBtn.setOnClickListener(v -> {
+                mapSearchKeyword = "";
+                if (searchInput != null) {
+                    searchInput.setText("");
+                }
+                hideKeyboard(v);
+                refreshMarkers();
+            });
+        }
+        if (searchInput != null) {
+            searchInput.setOnEditorActionListener((TextView tv, int actionId, android.view.KeyEvent event) -> {
+                if (actionId == EditorInfo.IME_ACTION_SEARCH && searchBtn != null) {
+                    searchBtn.performClick();
+                    return true;
+                }
+                return false;
+            });
+        }
 
         mapView.addMapListener(new MapListener() {
             @Override
@@ -166,17 +207,7 @@ public class NearbyEventsMapFragment extends Fragment {
         if (e.getVenueLatitude() == null || e.getVenueLongitude() == null) {
             return false;
         }
-        if (e.isPrivate()) {
-            return false;
-        }
-        ZonedDateTime now = ZonedDateTime.now();
-        try {
-            ZonedDateTime open = e.getRegistrationOpen();
-            ZonedDateTime close = e.getRegistrationClose();
-            return !now.isBefore(open) && !now.isAfter(close);
-        } catch (Exception ex) {
-            return false;
-        }
+        return !e.isPrivate();
     }
 
     private void buildTagChips(@NonNull View root) {
@@ -235,6 +266,35 @@ public class NearbyEventsMapFragment extends Fragment {
         return false;
     }
 
+    /**
+     * Text search: any tag contains the keyword (case-insensitive), or event title contains it.
+     */
+    private boolean passesMapSearchKeyword(Event e) {
+        if (mapSearchKeyword.isEmpty()) {
+            return true;
+        }
+        if (e.getTags() != null) {
+            for (String t : e.getTags()) {
+                if (t == null) {
+                    continue;
+                }
+                String nt = t.toLowerCase(Locale.US).trim();
+                if (!nt.isEmpty() && nt.contains(mapSearchKeyword)) {
+                    return true;
+                }
+            }
+        }
+        String title = e.getTitle();
+        return title != null && title.toLowerCase(Locale.US).contains(mapSearchKeyword);
+    }
+
+    private void hideKeyboard(View v) {
+        InputMethodManager imm = (InputMethodManager) requireContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (imm != null && v.getWindowToken() != null) {
+            imm.hideSoftInputFromWindow(v.getWindowToken(), 0);
+        }
+    }
+
     private void refreshMarkers() {
         if (mapView == null) {
             return;
@@ -243,9 +303,13 @@ public class NearbyEventsMapFragment extends Fragment {
         Set<String> selected = getSelectedTags();
         List<Event> filtered = new ArrayList<>();
         for (Event e : allEvents) {
-            if (passesTagFilter(e, selected)) {
-                filtered.add(e);
+            if (!passesTagFilter(e, selected)) {
+                continue;
             }
+            if (!passesMapSearchKeyword(e)) {
+                continue;
+            }
+            filtered.add(e);
         }
         double zoom = mapView.getZoomLevelDouble();
         List<MapMarkerGrouper.Group> groups = MapMarkerGrouper.groupEvents(filtered, zoom);
@@ -254,9 +318,16 @@ public class NearbyEventsMapFragment extends Fragment {
             m.setPosition(new GeoPoint(g.centroidLat, g.centroidLon));
             m.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM);
             m.setTitle(MapMarkerGrouper.titleForGroup(g));
+            boolean singleEventMarker = g.events.size() == 1;
             if (g.events.size() == 1) {
-                String d = g.events.get(0).getDescription();
-                m.setSnippet(d != null && d.length() > 80 ? d.substring(0, 77) + "…" : d);
+                Event one = g.events.get(0);
+                String addr = one.getVenueAddress();
+                if (addr != null && !addr.trim().isEmpty()) {
+                    m.setSnippet(addr.trim());
+                } else {
+                    String d = one.getDescription();
+                    m.setSnippet(d != null && d.length() > 80 ? d.substring(0, 77) + "…" : d);
+                }
             } else {
                 m.setSnippet(getString(R.string.pick_event_from_cluster));
             }
@@ -265,6 +336,10 @@ public class NearbyEventsMapFragment extends Fragment {
                 return true;
             });
             mapView.getOverlays().add(m);
+            if (singleEventMarker) {
+                // Keep the event name visible above individual pins.
+                m.showInfoWindow();
+            }
         }
         mapView.invalidate();
     }

--- a/code/app/src/main/res/layout/fragment_create_event.xml
+++ b/code/app/src/main/res/layout/fragment_create_event.xml
@@ -273,7 +273,7 @@
 
             </LinearLayout>
 
-            <!-- Venue & geolocation (optional) -->
+            <!-- Venue: street address only (coordinates are derived automatically) -->
 
             <TextView
                 android:layout_width="wrap_content"
@@ -284,37 +284,26 @@
                 android:textColor="@color/primary_deep"
                 android:textSize="20sp" />
 
-            <LinearLayout
+            <EditText
+                android:id="@+id/edit_venue_address"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="30dp"
-                android:orientation="horizontal">
+                android:background="@color/white"
+                android:hint="@string/venue_address_hint"
+                android:importantForAutofill="no"
+                android:inputType="textPostalAddress"
+                android:padding="10dp"
+                android:textSize="18sp" />
 
-                <EditText
-                    android:id="@+id/edit_venue_latitude"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:background="@color/white"
-                    android:hint="@string/venue_latitude_hint"
-                    android:importantForAutofill="no"
-                    android:inputType="numberDecimal|numberSigned"
-                    android:padding="10dp"
-                    android:textSize="18sp" />
-
-                <EditText
-                    android:id="@+id/edit_venue_longitude"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:layout_weight="1"
-                    android:background="@color/white"
-                    android:hint="@string/venue_longitude_hint"
-                    android:importantForAutofill="no"
-                    android:inputType="numberDecimal|numberSigned"
-                    android:padding="10dp"
-                    android:textSize="18sp" />
-            </LinearLayout>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="30dp"
+                android:layout_marginTop="4dp"
+                android:text="@string/venue_address_no_coordinates_note"
+                android:textColor="@color/grey_light"
+                android:textSize="12sp" />
 
             <CheckBox
                 android:id="@+id/checkbox_require_geolocation"

--- a/code/app/src/main/res/layout/fragment_list_with_bottom_bar.xml
+++ b/code/app/src/main/res/layout/fragment_list_with_bottom_bar.xml
@@ -43,13 +43,30 @@
             style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Search events by keyword">
+            android:hint="@string/home_filter_keyword_hint">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/input_search_keyword"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/input_search_tag_layout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="@string/home_filter_tag_hint">
+
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/input_search_tag"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:completionThreshold="1"
+                android:importantForAutofill="no" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <LinearLayout

--- a/code/app/src/main/res/layout/fragment_nearby_events_map.xml
+++ b/code/app/src/main/res/layout/fragment_nearby_events_map.xml
@@ -30,6 +30,58 @@
         app:layout_constraintStart_toStartOf="@id/map_header"
         app:layout_constraintTop_toTopOf="@id/map_header" />
 
+    <LinearLayout
+        android:id="@+id/map_search_row"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:elevation="3dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/map_header">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/map_search_layout"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="6dp"
+            android:layout_weight="1"
+            android:hint="@string/map_search_tag_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_map_search"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionSearch"
+                android:inputType="text"
+                android:maxLines="1" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_map_search"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="4dp"
+            android:backgroundTint="@color/primary_dark"
+            android:text="@string/map_search_apply"
+            android:textSize="12sp"
+            app:cornerRadius="8dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_map_search_clear"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/map_search_clear"
+            android:textColor="@color/primary_deep"
+            android:textSize="12sp" />
+    </LinearLayout>
+
     <HorizontalScrollView
         android:id="@+id/tag_scroll"
         android:layout_width="0dp"
@@ -41,7 +93,7 @@
         android:scrollbars="none"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/map_header">
+        app:layout_constraintTop_toBottomOf="@id/map_search_row">
 
         <com.google.android.material.chip.ChipGroup
             android:id="@+id/chip_group_tags"

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -101,20 +101,27 @@
     <string name="decline_invite">Decline</string>
     <string name="generate_qr_code">Generate QR Code</string>
 
-    <string name="venue_location">Venue coordinates (optional, for map)</string>
-    <string name="venue_latitude_hint">Latitude</string>
-    <string name="venue_longitude_hint">Longitude</string>
+    <string name="venue_location">Venue address (optional, for map)</string>
+    <string name="venue_address_hint">Street address (do not use latitude/longitude)</string>
+    <string name="venue_address_no_coordinates_note">Enter a real address. Do not paste coordinates—the app looks up the location for you.</string>
     <string name="require_geolocation_waitlist">Require device location to join waitlist</string>
     <string name="geolocation_radius_hint">Max distance from venue (meters)</string>
     <string name="geo_verification_radius_note">Default 500 m if left empty when verification is on.</string>
     <string name="event_tags_hint">Tags (comma-separated, for search and map)</string>
-    <string name="error_venue_coords_incomplete">Enter both latitude and longitude, or leave both empty.</string>
-    <string name="error_venue_coords_invalid">Latitude and longitude must be valid decimal numbers.</string>
-    <string name="error_geo_requires_venue">Turn off geolocation verification or set a venue location.</string>
+    <string name="error_venue_address_invalid">Enter a valid venue address (at least a few characters).</string>
+    <string name="error_venue_address_geocode">Could not find that address. Try a fuller street address.</string>
+    <string name="error_use_address_not_coordinates">Enter a street address, not latitude/longitude numbers.</string>
+    <string name="error_geo_requires_venue">Turn off geolocation verification or enter a venue street address.</string>
     <string name="error_geo_radius_invalid">Geolocation radius must be a positive number.</string>
     <string name="waiting_list_geo_notice">Your device location will be checked against the event venue when you join.</string>
+    <string name="home_filter_keyword_hint">Search title, description, or tags</string>
+    <string name="home_filter_tag_hint">Filter by tag name</string>
+
     <string name="nearby_map_title">Nearby events</string>
-    <string name="nearby_map_tag_hint">Toggle tags to show only matching events (OpenStreetMap).</string>
+    <string name="nearby_map_tag_hint">Search by tag or event name, toggle chips, or both (OpenStreetMap).</string>
+    <string name="map_search_tag_hint">Search by tag or event title</string>
+    <string name="map_search_apply">Search</string>
+    <string name="map_search_clear">Clear</string>
     <string name="location_permission_required">Location permission is needed for this feature.</string>
     <string name="location_unavailable">Could not read your location. Try again or move outdoors.</string>
     <string name="pick_event_from_cluster">Choose an event</string>


### PR DESCRIPTION
## Summary
- Require organizers to provide venue addresses instead of manual coordinates and geocode those addresses for map placement.
- Add map search controls so users can find events by tag or event title directly on the map.
- Improve map readability by showing event names above single-event pins and keeping all public mappable events discoverable.

## Test plan
- [x] Create/edit an event with a real street address and confirm it saves.
- [x] Enter coordinate text in the address field and confirm validation blocks it.
- [x] Open Nearby Map and search by a known tag (for example, `funday`) and confirm matching events appear.
- [x] Confirm single-event pins display the event name above the marker.